### PR TITLE
Update dependencies. The one I am really interested in is

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Provides build-time solution for wro4j with Gradle.
 
-Latest release: 1.7.9.Beta2
+Latest release: 2.7.9.Beta3
 
 ## Getting Started
 
@@ -35,7 +35,7 @@ buildscript {
         maven { url 'https://dl.bintray.com/ilyaai/maven' }
     }
     dependencies {
-        classpath 'ro.isdc.wro4j.gradle:wro4j-gradle-plugin:1.7.9.Beta2'
+        classpath 'ro.isdc.wro4j.gradle:wro4j-gradle-plugin:1.7.9.Beta3'
     }
 }
 apply plugin: 'java'

--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,12 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.5'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
     }
 }
 
 group = 'ro.isdc.wro4j.gradle'
-version = '1.7.9.Beta2'
+version = '1.7.9.Beta3'
 
 apply plugin: 'groovy'
 apply plugin: 'maven'
@@ -24,7 +24,7 @@ repositories {
 
 dependencies {
     compile gradleApi()
-    compile ('ro.isdc.wro4j:wro4j-extensions:1.7.9') {
+    compile ('ro.isdc.wro4j:wro4j-extensions:1.8.0') {
         exclude module: 'groovy-all'
     }
     compile 'org.mockito:mockito-all:1.10.19'
@@ -32,7 +32,7 @@ dependencies {
 
     runtime 'javax.servlet:javax.servlet-api:3.1.0'
 
-    testCompile ('com.netflix.nebula:nebula-test:3.1.0') {
+    testCompile ('com.netflix.nebula:nebula-test:4.0.0') {
         exclude module: 'groovy-all'
     }
 }


### PR DESCRIPTION
wro4j-extensions 1.8.0 because it fixes an issue with
googleClosureSimple preProcessor. See here
https://github.com/wro4j/wro4j/commit/4f767db56bc36a0d0a349e6c69af36303426dd73
